### PR TITLE
Add `-w` option for watching files

### DIFF
--- a/extras/completion/bash
+++ b/extras/completion/bash
@@ -1,9 +1,9 @@
 _maid() {
   case "$2","$3" in
     -*,*)
-      COMPREPLY=( $(compgen -W "-h -l -n -q -f --help --list --dry-run --quiet --taskfile" -- "$2") )
+      COMPREPLY=( $(compgen -W "-h -l -n -q -f -w -r --help --list --dry-run --quiet --taskfile --watch --restart" -- "$2") )
       ;;
-    *,-f | *,--maidfile)
+    *,-f | *,--maidfile | *,-w | *,--watch)
       COMPREPLY=( $(compgen -f -- "$2") )
       ;;
     *)

--- a/extras/completion/fish
+++ b/extras/completion/fish
@@ -1,9 +1,12 @@
-complete -c maid -n "__fish_is_first_arg" -f
+complete -c maid -e
+complete -c maid -n "__fish_is_first_token" -f
 complete -c maid -a "(maid -l | sed 's/ \(.\)/\t\L\1/')"
 complete -c maid -s h -l help -d "display usage"
 complete -c maid -s l -l list -d "list tasks concisely"
 complete -c maid -s n -l dry-run -d "don't run anything, only display commands"
 complete -c maid -s q -l quiet -d "don't display anything"
-complete -c maid -s f -l taskfile -d "use tasks in file"
+complete -c maid -s f -l taskfile -r -d "use tasks in file"
+complete -c maid -s w -l watch -r -d "watch files in path"
+complete -c maid -s r -l restart -d "restart tasks instead of waiting"
 
 # vim: ft=fish

--- a/extras/completion/zsh
+++ b/extras/completion/zsh
@@ -18,6 +18,8 @@ _maid() {
     "(dry-run)"{-n,--dry-run}"[don't run anything, only display commands]" \
     "(quiet)"{-q,--quiet}"[don't display anything]" \
     "(taskfile)"{-f,--taskfile=}"[use tasks in file]:maidfile:_files" \
+    "(watch)"{-w,--watch=}"[watch tasks in path]:watch:_files" \
+    "(restart)"{-r,--restart}"[restart tasks instead of waiting]" \
     ":task:_maid_tasks" \
     "*:args:_default"
 }

--- a/maid-build.cabal
+++ b/maid-build.cabal
@@ -19,7 +19,7 @@ source-repository head
   location: https://github.com/rniii/maid.git
 
 common base
-  ghc-options: -Wall -Wno-name-shadowing
+  ghc-options: -Wall -Wno-name-shadowing -threaded
   default-language: Haskell2010
   build-depends: base >= 4.7 && <5
 
@@ -31,13 +31,14 @@ library
     Maid.Parser,
   build-depends:
     ansi-terminal ^>= 1.1,
+    bytestring ^>= 0.11,
     directory ^>= 1.3,
     filepath ^>= 1.5,
-    process ^>= 1.6,
-    bytestring ^>= 0.11,
-    text ^>= 2.0,
+    fsnotify ^>= 0.4,
     mtl ^>= 2.2,
+    process ^>= 1.6,
     temporary ^>= 1.3,
+    text ^>= 2.0,
 
 executable maid
   import:         base


### PR DESCRIPTION
Pretty rudimentary for now. Could have been done with [watchexec](https://github.com/watchexec/watchexec), but I think its useful as a builtin feature.

Example `dev` task:

````md
### dev

```sh
maid -w src build &
maid -w src -w public serve &
wait
```
````

## TODO

- [ ] Ignoring file patterns
- [ ] Handle `.gitignore` etc
- [ ] Option to restart process instead of waiting